### PR TITLE
Add HDF5 helpers with backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,5 +205,17 @@ visione compose build core  # rebuild only the core service
 visione compose up -d core  # restart the core service with the newly built image
 ```
 
+### HDF5 Features File Layout
+
+Feature extraction services store vectors in HDF5 files. Two layouts are
+supported:
+
+1. **Dataset layout** – datasets `/ids` and `/data` contain the record IDs and
+   the feature matrix.
+2. **Group layout** – one group per record identified by its ID; each group
+   stores the feature array (e.g. under `feature_vector`).
+
+In both cases the file attribute `features_name` specifies the type of features.
+
 ## Need Help or Have Feedback? 
 We encourage you to [open a discussion](https://github.com/aimh-lab/visione/discussions) to request assistance with using this project, make suggestions, or report any issues. 

--- a/visione/services/analysis/frame-cluster/cluster.py
+++ b/visione/services/analysis/frame-cluster/cluster.py
@@ -4,13 +4,13 @@ from pathlib import Path
 import sys
 import warnings
 
-import h5py
 import numpy as np
 from scipy.spatial.distance import pdist, squareform
 from sklearn.cluster import AgglomerativeClustering
 
 from visione import cli_progress as progress
 from visione.savers import GzipJsonlFile
+from visione.utils.hdf5_helpers import load_features_compat
 
 
 loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
@@ -80,9 +80,10 @@ def cluster(X):
 
 def main(args):
 
-    with h5py.File(args.features_file, 'r') as f:
-        frames_ids = f['ids'].asstr()[:]
-        frames_features = f['data'][:]
+    ids_and_features = list(load_features_compat([args.features_file]))
+    frames_ids, frames_features = zip(*ids_and_features)
+    frames_ids = np.asarray(frames_ids)
+    frames_features = np.stack(frames_features)
 
     frames_codes = cluster(frames_features)
 

--- a/visione/services/index/faiss-index-manager/build.py
+++ b/visione/services/index/faiss-index-manager/build.py
@@ -5,12 +5,12 @@ import re
 import sys
 
 import faiss
-import h5py
 import more_itertools
 import numpy as np
 from tqdm import tqdm
 
 from visione import load_config, CliProgress
+from visione.utils.hdf5_helpers import load_features_compat, peek_features_attributes
 
 
 loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
@@ -26,26 +26,6 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 
-def peek_features_attributes(h5file):
-    with h5py.File(h5file, 'r') as f:
-        features_dim = f['data'].shape[1]
-        features_name = f.attrs['features_name']
-        return features_dim, features_name
-
-
-def load_features(hdf5_files):
-    progress = CliProgress(total=0)
-
-    for hdf5_file in hdf5_files:
-        with h5py.File(hdf5_file, 'r') as h5file:
-            ids = h5file['ids'].asstr()[:]
-            features = h5file['data'][:]
-
-            progress.total += len(features)
-            ids_and_features = zip(ids, features)
-            ids_and_features = progress(ids_and_features)
-
-            yield from ids_and_features
 
 
 def create(args):
@@ -63,7 +43,7 @@ def create(args):
     # load features
     features_files = args.features_dir.glob('*/*.hdf5')
     features_files = sorted(features_files)
-    ids_and_features = load_features(features_files)
+    ids_and_features = load_features_compat(features_files)
 
     # peek features to get type and dimensionality
     dim, features_name = peek_features_attributes(features_files[0])
@@ -132,15 +112,15 @@ def add(args):
 
     def _add_single_features_file(video_features_file, index, idmap):
         # load ids and features to be added
-        with h5py.File(video_features_file, 'r') as h5file:
-            ids = h5file['ids'].asstr()[:]
+        ids_and_features = list(load_features_compat([video_features_file]))
+        ids, features = zip(*ids_and_features)
 
-            positions = [i for i, x in enumerate(idmap) if x in ids]
-            if not args.force and positions:  # frames with this video_id are present in the index
-                print(f'Skipping adding to FAISS index, already present.')
-                return index, idmap
+        positions = [i for i, x in enumerate(idmap) if x in ids]
+        if not args.force and positions:
+            print('Skipping adding to FAISS index, already present.')
+            return index, idmap
 
-            features = h5file['data'][:]
+        features = np.stack(features)
 
         if args.force and positions:  # when forcing, remove existing entries for this video from the index
             idmap = [x for i, x in enumerate(idmap) if i not in positions]

--- a/visione/services/index/str-feature-encoder/encode.py
+++ b/visione/services/index/str-feature-encoder/encode.py
@@ -7,12 +7,12 @@ from pathlib import Path
 import random
 import sys
 
-import h5py
 import more_itertools
 import surrogate
 
 from visione import load_config, CliProgress, cli_progress
 from visione.savers import GzipJsonlFile
+from visione.utils.hdf5_helpers import load_features_compat, peek_features_attributes
 
 
 loggers = [logging.getLogger(name) for name in logging.root.manager.loggerDict]
@@ -33,16 +33,14 @@ def get_features(features_input_template, video_ids):
 
     # peek features name
     features_h5 = features_input_template.format(video_id=video_ids[0])
-    with h5py.File(features_h5, 'r') as f:
-        features_name = f.attrs['features_name']
-        features_dim = f['data'].shape[1]
+    features_dim, features_name = peek_features_attributes(features_h5)
 
     # generate training set
     def _gen():
         for video_id in video_ids:
             features_h5 = features_input_template.format(video_id=video_id)
-            with h5py.File(features_h5, 'r') as f:
-                yield from f['data']
+            for _, feature in load_features_compat([features_h5]):
+                yield feature
 
     train_features = _gen()
     return features_dim, features_name, train_features
@@ -91,17 +89,17 @@ def load_or_build_encoder(encoder_filename, encoder_config, dim, features, n_tra
 
 def process_video_id(features_input_file, str_output_file, encoder, force, save_every):
 
-    with h5py.File(features_input_file, 'r') as f:
-        if str_output_file.exists():
-            if force:  # if forced, delete old file
-                str_output_file.unlink()
-            else:
-                print(f'Skipping STR features encoding, using existing file:', str_output_file.name)
-                return
+    if str_output_file.exists():
+        if force:
+            str_output_file.unlink()
+        else:
+            print(f'Skipping STR features encoding, using existing file: {str_output_file.name}')
+            return
 
-        # get ids and features matrix
-        ids = f['ids'].asstr()[:]
-        features = f['data'][:]
+    ids_and_features = list(load_features_compat([features_input_file]))
+    ids, features = zip(*ids_and_features)
+    ids = np.asarray(ids)
+    features = np.stack(features)
 
     # open saver
     str_output_file.parent.mkdir(parents=True, exist_ok=True)

--- a/visione/utils/hdf5_helpers.py
+++ b/visione/utils/hdf5_helpers.py
@@ -1,0 +1,60 @@
+import h5py
+import numpy as np
+from pathlib import Path
+from typing import Iterable, Iterator, Tuple
+
+from visione import CliProgress
+
+
+def peek_features_attributes(h5file: Path) -> Tuple[int, str]:
+    """Return dimensionality and name of the features stored in ``h5file``.
+
+    Works with both dataset and per-record group layouts.
+    """
+    with h5py.File(h5file, "r") as f:
+        features_name = f.attrs.get("features_name")
+        if "data" in f:
+            dim = f["data"].shape[1]
+            return dim, features_name
+        # per-record groups
+        first_key = next(iter(f.keys()))
+        group = f[first_key]
+        if "feature_vector" in group:
+            ds = group["feature_vector"]
+        elif "feature" in group:
+            ds = group["feature"]
+        else:
+            ds = next(iter(group.values()))
+        dim = ds.shape[-1]
+        return dim, features_name
+
+
+def load_features_compat(hdf5_files: Iterable[Path]) -> Iterator[Tuple[str, np.ndarray]]:
+    """Yield ``(id, feature_vector)`` from a sequence of HDF5 files.
+
+    Compatible with files storing features either as ``ids``/``data`` datasets
+    or as one group per record.
+    """
+    progress = CliProgress(total=0)
+
+    for hdf5_file in hdf5_files:
+        with h5py.File(hdf5_file, "r") as f:
+            if "ids" in f and "data" in f:
+                ids = f["ids"].asstr()[:]
+                features = f["data"][:]
+                progress.total += len(features)
+                for item in progress(zip(ids, features)):
+                    yield item
+            else:
+                keys = list(f.keys())
+                progress.total += len(keys)
+                for record_id in progress(keys):
+                    group = f[record_id]
+                    if "feature_vector" in group:
+                        ds = group["feature_vector"][:]
+                    elif "feature" in group:
+                        ds = group["feature"][:]
+                    else:
+                        dsname = next(iter(group.keys()))
+                        ds = group[dsname][:]
+                    yield record_id, np.asarray(ds)


### PR DESCRIPTION
## Summary
- add `hdf5_helpers` with utilities to read both dataset and group based HDF5 layouts
- update clustering, STR encoding and FAISS building scripts to use the helpers
- document supported HDF5 feature layouts

## Testing
- `pip install -e .` *(fails: BackendUnavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68801ec99ed8832bb7ced41807155a64