### PR TITLE
Enable GPU runtime for ffmpeg service

### DIFF
--- a/visione/services/analysis-services.yaml
+++ b/visione/services/analysis-services.yaml
@@ -2,6 +2,9 @@ services:
   ffmpeg:
     image: jrottenberg/ffmpeg:5.1.2-nvidia2004
     entrypoint: []
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
     volumes:
       - ${VISIONE_ROOT}:/data
       - ${VISIONE_CACHE}:/cache


### PR DESCRIPTION
## Summary
- adjust analysis services to run ffmpeg container with the nvidia runtime and all GPUs visible

## Testing
- `pip install --no-deps -e .`
- `visione --help`

------
https://chatgpt.com/codex/tasks/task_e_68803373117c832b97e8563e6e3cb7b3